### PR TITLE
Embeddable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,30 @@ x.add_output('G', r'$g^*$', side='left')
 x.write('mdf')
 ```
 ![XDSM of MDF](https://github.com/mdolab/pyXDSM/blob/master/images_for_readme/mdf.png)
+
+
+This will output three useful files.  The files `mdf.tex` will be a standalone document that
+is also compiled to `mdf.pdf`.  In addition `mdf_tikzpicture.tex` can be embedded in another
+tex file.
+
+```
+\begin{figure}
+  \caption{Example of an MDF XDSM.}
+  \centering
+  \input{mdf_tikzpicture}
+  \label{fig:xdsm}
+\end{figure}
+```
+
+The following is required to be in the preamble of the document:
+
+```
+\usepackage{geometry}
+\usepackage{amsfonts}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{tikz}
+
+\input{ diagram_border_path }
+
+```

--- a/README.md
+++ b/README.md
@@ -75,10 +75,18 @@ x.write('mdf')
 ```
 ![XDSM of MDF](https://github.com/mdolab/pyXDSM/blob/master/images_for_readme/mdf.png)
 
+This will output `mdf.tex`, a standalone tex document that is also compiled to `mdf.pdf`.
 
-This will output three useful files.  The files `mdf.tex` will be a standalone document that
-is also compiled to `mdf.pdf`.  In addition `mdf_tikzpicture.tex` can be embedded in another
-tex file.
+## Embedding the diagram directly in LaTeX
+
+In addition, the file, `mdf_tikzpicture.tex`, can be embedded in another
+tex file.  This file is generated with the `write_embeddable` method.
+
+```python
+x.write_embeddable('mdf')
+```
+
+Which can be input directly into a LaTeX file:
 
 ```
 \begin{figure}
@@ -98,6 +106,6 @@ The following is required to be in the preamble of the document:
 \usepackage{amssymb}
 \usepackage{tikz}
 
-\input{ diagram_border_path }
+\usetikzlibrary{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows}
 
 ```

--- a/pyxdsm/XDSM.py
+++ b/pyxdsm/XDSM.py
@@ -10,7 +10,8 @@ tikzpicture_template = r"""
 % \usepackage{{amssymb}}
 % \usepackage{{tikz}}
 
-% \input{{ {diagram_border_path} }}
+% \usetikzlibrary{{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows}} 
+
 
 %%% End Preamble %%%
 
@@ -229,8 +230,7 @@ class XDSM(object):
         return paths_str
 
 
-    def write(self, file_name, tikzpicture=True, build=True):
-
+    def write(self, file_name, build=True):
         nodes = self._build_node_grid()
         edges = self._build_edges()
 
@@ -238,17 +238,9 @@ class XDSM(object):
         diagram_border_path = os.path.join(module_path, 'diagram_border')
         diagram_styles_path = os.path.join(module_path, 'diagram_styles')
 
-        tikzpicture_str = tikzpicture_template.format(nodes=nodes, edges=edges,
-                                                      diagram_border_path=diagram_border_path,
-                                                      diagram_styles_path=diagram_styles_path)
-
         tex_str = tex_template.format(nodes=nodes, edges=edges,
                                       diagram_border_path=diagram_border_path,
                                       diagram_styles_path=diagram_styles_path)
-
-        if tikzpicture:
-            with open(file_name + '_tikzpicture.tex', 'w') as f:
-                f.write(tikzpicture_str)
 
         with open(file_name + '.tex', 'w') as f:
             f.write(tex_str)
@@ -256,5 +248,20 @@ class XDSM(object):
         if build:
             os.system('pdflatex ' + file_name + '.tex')
 
+
+    def write_embeddable(self, filename):
+
+        nodes = self._build_node_grid()
+        edges = self._build_edges()
+
+        module_path = os.path.dirname(__file__)
+        diagram_styles_path = os.path.join(module_path, 'diagram_styles')
+
+        tikzpicture_str = tikzpicture_template.format(nodes=nodes,
+                                                      edges=edges,
+                                                      diagram_styles_path=diagram_styles_path)
+
+        with open(filename + '_tikzpicture.tex', 'w') as f:
+            f.write(tikzpicture_str)
 
 

--- a/pyxdsm/diagram_border.tex
+++ b/pyxdsm/diagram_border.tex
@@ -1,10 +1,3 @@
 % Define the set of tikz packages to be included in the architecture diagram document
 
 \usetikzlibrary{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows} 
-
-% Set the border around all of the architecture diagrams to be tight to the diagrams themselves
-% (i.e. no longer need to tinker with page size parameters)
-
-\usepackage[active,tightpage]{preview}
-\PreviewEnvironment{tikzpicture}
-\setlength{\PreviewBorder}{5pt}

--- a/pyxdsm/diagram_styles.tex
+++ b/pyxdsm/diagram_styles.tex
@@ -1,6 +1,6 @@
 % Define all the styles used to produce XDSMs for MDO
 
-\tikzstyle{every node}=[font=\sffamily]
+\tikzstyle{every node}=[font=\sffamily,align=center]
 
 % Component types
 \tikzstyle{Optimization} = [rounded rectangle,draw,fill=blue!20,inner sep=6pt,minimum height=1cm,text badly centered]


### PR DESCRIPTION
Adds method `write_embeddable(filename)` which outputs a LaTeX file `filename_tikzpicture.tex` that can be directly embedded in other documents.  This removes the need to keep a binary pdf file in a repository for git-controlled LaTeX documents.

diagram_borders.tex is still used for the standalone tex file but probably isn't needed anymore.  It's easier just to copy the necessary lines to the preamble.