### PR TITLE
removed diagram_border.tex, and updated the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,24 +75,18 @@ x.write('mdf')
 ```
 ![XDSM of MDF](https://github.com/mdolab/pyXDSM/blob/master/images_for_readme/mdf.png)
 
-This will output `mdf.tex`, a standalone tex document that is also compiled to `mdf.pdf`.
+This will output `mdf.tex`, a standalone tex document that (by default) is also compiled to `mdf.pdf`.
 
 ## Embedding the diagram directly in LaTeX
 
-In addition, the file, `mdf_tikzpicture.tex`, can be embedded in another
-tex file.  This file is generated with the `write_embeddable` method.
-
-```python
-x.write_embeddable('mdf')
-```
-
-Which can be input directly into a LaTeX file:
+In addition, the file, `mdf.tikz`, can be embedded in another tex file using
+the `\input` command:  
 
 ```
 \begin{figure}
   \caption{Example of an MDF XDSM.}
   \centering
-  \input{mdf_tikzpicture}
+  \input{mdf.tikz}
   \label{fig:xdsm}
 \end{figure}
 ```
@@ -107,5 +101,4 @@ The following is required to be in the preamble of the document:
 \usepackage{tikz}
 
 \usetikzlibrary{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows}
-
 ```

--- a/pyxdsm/XDSM.py
+++ b/pyxdsm/XDSM.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 
 tikzpicture_template = r"""
-%%% Preamble %%%
+%%% Preamble Requirements %%%
 % \usepackage{{geometry}}
 % \usepackage{{amsfonts}}
 % \usepackage{{amsmath}}
@@ -12,8 +12,7 @@ tikzpicture_template = r"""
 
 % \usetikzlibrary{{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows}} 
 
-
-%%% End Preamble %%%
+%%% End Preamble Requirements %%%
 
 \input{{ {diagram_styles_path} }}
 \begin{{tikzpicture}}
@@ -37,7 +36,9 @@ tex_template = r"""
 \usepackage{{amssymb}}
 \usepackage{{tikz}}
 
-\input{{ {diagram_border_path} }}
+% Define the set of tikz packages to be included in the architecture diagram document
+\usetikzlibrary{{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows}}
+
 
 % Set the border around all of the architecture diagrams to be tight to the diagrams themselves
 % (i.e. no longer need to tinker with page size parameters)
@@ -243,7 +244,6 @@ class XDSM(object):
         edges = self._build_edges()
 
         module_path = os.path.dirname(__file__)
-        diagram_border_path = os.path.join(module_path, 'diagram_border')
         diagram_styles_path = os.path.join(module_path, 'diagram_styles')
 
         tikzpicture_str = tikzpicture_template.format(nodes=nodes,
@@ -255,7 +255,6 @@ class XDSM(object):
 
         tex_str = tex_template.format(nodes=nodes, edges=edges,
                                       tikzpicture_path=file_name + '.tikz',
-                                      diagram_border_path=diagram_border_path,
                                       diagram_styles_path=diagram_styles_path)
 
         with open(file_name + '.tex', 'w') as f:

--- a/pyxdsm/diagram_border.tex
+++ b/pyxdsm/diagram_border.tex
@@ -1,3 +1,0 @@
-% Define the set of tikz packages to be included in the architecture diagram document
-
-\usetikzlibrary{arrows,chains,positioning,scopes,shapes.geometric,shapes.misc,shadows} 


### PR DESCRIPTION
Some additional cleanup.  Removed `diagram_borders.tex`, it's arguably simpler just to document the required `/usepackage` and `/usetikzlibrary` commands.  README now accurately reflects the tikz file output.