### PR TITLE
Updated CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     - texlive-latex-extra
 
 cache:
-  pip
+  pip: true
   apt: true
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,19 +46,13 @@ install:
   fi
 
 - pip install testflo;
-- pip install .
+- pip install . -e
 
 # display summary of installed packages and their versions
 - conda list
 
 script:
 - testflo . -v
-
-# now we build examples as a test
-- cd examples 
-- python kitchen_sink.py
-- python mat_eqn.py
-- python mdf.py
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   fi
 
 - pip install testflo;
-- pip install . -e
+- pip install -e .
 
 # display summary of installed packages and their versions
 - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,12 @@ install:
 script:
 - testflo . -v
 
+# now we build examples as a test
+- cd examples 
+- python kitchen_sink.py
+- python mat_eqn.py
+- python mdf.py
+
 deploy:
   provider: pypi
   user: "__token__"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
 language: python
 
 env:
-  - PY=2.7
   - PY=3.6
+  - PY=3.7
+  - PY=3.8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
 
-language: generic
+language: python
 
 env:
   - PY=2.7
@@ -15,6 +15,7 @@ addons:
     - texlive-latex-extra
 
 cache:
+  pip
   apt: true
   directories:
     - $HOME/.cache/pip
@@ -33,13 +34,6 @@ before_install:
     rm -rf $HOME/miniconda;
   fi
 
-- if [ -f $HOME/.cache/pip ]; then
-    echo "cached pip found -- nothing to do";
-  else
-    NOT_CACHED_PIP=1;
-    rm -rf $HOME/.cache/pip;
-  fi
-
 - rm -rf $HOME/miniconda/lib/python$PY/site-packages/pyXDSM
 
 install:
@@ -54,23 +48,14 @@ install:
     export PATH=$HOME/miniconda/bin:$PATH;
   fi
 
-- if [ "$NOT_CACHED_PIP" ]; then
-    pip install --upgrade pip;
-  fi
-
+- pip install testflo;
 - pip install .
-
 
 # display summary of installed packages and their versions
 - conda list
 
 script:
-- cd examples
-- python kitchen_sink.py
-- python mat_eqn.py
-- python mdf.py
-- ls
-- cd ..
+- testflo . -v
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ addons:
     - texlive-latex-extra
 
 cache:
-  pip: true
   apt: true
   directories:
-    - $HOME/.cache/pip
     - $HOME/miniconda
 
 before_install:
@@ -34,8 +32,6 @@ before_install:
     NOT_CACHED_CONDA=1;
     rm -rf $HOME/miniconda;
   fi
-
-- rm -rf $HOME/miniconda/lib/python$PY/site-packages/pyXDSM
 
 install:
 - if [ "$NOT_CACHED_CONDA" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
 
-language: python
+language: generic
 
 env:
   - PY=3.6
@@ -35,7 +35,7 @@ before_install:
 
 install:
 - if [ "$NOT_CACHED_CONDA" ]; then
-    wget "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh" -O miniconda.sh;
+    wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
     chmod +x miniconda.sh;
     ./miniconda.sh -b  -p $HOME/miniconda;
     export PATH=$HOME/miniconda/bin:$PATH;

--- a/pyxdsm/tests/test_xdsm.py
+++ b/pyxdsm/tests/test_xdsm.py
@@ -1,7 +1,6 @@
 import unittest
 import os
-
-from pyxdsm.XDSM import XDSM
+from pyxdsm.XDSM import XDSM, __file__
 
 
 class TestXDSM(unittest.TestCase):
@@ -25,6 +24,23 @@ class TestXDSM(unittest.TestCase):
             shutil.rmtree(self.tempdir)
         except OSError:
             pass
+
+    def test_examples(self):
+        '''
+        This test just builds the three examples, and assert that the output files exist.
+        Unlike the other tests, this one requires LaTeX to be available.
+        '''
+        os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../examples'))
+        filenames = ['kitchen_sink', 'mdf']
+        for f in filenames:
+            os.system('python {}.py'.format(f))
+            self.assertTrue(os.path.isfile(f + '.tikz'))
+            self.assertTrue(os.path.isfile(f + '.tex'))
+            self.assertTrue(os.path.isfile(f + '.pdf'))
+        os.system('python mat_eqn.py')
+        self.assertTrue(os.path.isfile('mat_eqn_example.pdf'))
+        # change back to previous directory
+        os.chdir(self.tempdir)
 
     def test_options(self):
 


### PR DESCRIPTION
- removed pip cache since it's not really necessary
- updated conda installer path and cleared conda cache just once to clean everything up
- installed testflo as dependency
- dropped py2 support, and added additional py3 testing environments
- updated script to use new tests rather than just building the examples

Maybe it's still useful to keep building the examples? I can add that back if we want.