### PR TITLE
Test fix

### DIFF
--- a/pyxdsm/tests/test_xdsm.py
+++ b/pyxdsm/tests/test_xdsm.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 from pyxdsm.XDSM import XDSM, __file__
-
+from numpy.distutils.exec_command import find_executable
 
 class TestXDSM(unittest.TestCase):
 
@@ -36,7 +36,10 @@ class TestXDSM(unittest.TestCase):
             os.system('python {}.py'.format(f))
             self.assertTrue(os.path.isfile(f + '.tikz'))
             self.assertTrue(os.path.isfile(f + '.tex'))
-            self.assertTrue(os.path.isfile(f + '.pdf'))
+            # look for the pdflatex executable
+            pdflatex = find_executable('pdflatex') is not None
+            # if no pdflatex, then do not assert that the pdf was compiled
+            self.assertTrue(not pdflatex or (pdflatex and os.path.isfile(f + '.pdf')))
         os.system('python mat_eqn.py')
         self.assertTrue(os.path.isfile('mat_eqn_example.pdf'))
         # change back to previous directory

--- a/pyxdsm/tests/test_xdsm.py
+++ b/pyxdsm/tests/test_xdsm.py
@@ -39,7 +39,7 @@ class TestXDSM(unittest.TestCase):
             # look for the pdflatex executable
             pdflatex = find_executable('pdflatex') is not None
             # if no pdflatex, then do not assert that the pdf was compiled
-            self.assertTrue(not pdflatex or (pdflatex and os.path.isfile(f + '.pdf')))
+            self.assertTrue(not pdflatex or os.path.isfile(f + '.pdf'))
         os.system('python mat_eqn.py')
         self.assertTrue(os.path.isfile('mat_eqn_example.pdf'))
         # change back to previous directory


### PR DESCRIPTION
## Purpose
The test added in #25 is updated, so that it only checks for the existence of the PDF output if pdflatex is installed on the system.

@onodip very helpfully linked me to the implementation in [OpenMDAO-XDSM](https://github.com/onodip/OpenMDAO-XDSM/blob/master/omxdsm/tests/test_xdsm_viewer.py#L167) which is the basis for this PR.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)


## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
