### PR TITLE
Add option to write/build files in a specified directory

### DIFF
--- a/tests/test_xdsm.py
+++ b/tests/test_xdsm.py
@@ -306,6 +306,23 @@ class TestXDSM(unittest.TestCase):
         # To be sure, check the length, otherwise a missing last line could get unnoticed because of using zip
         self.assertEqual(len(new_lines), len(sample_lines))
 
+    def test_write_outdir(self):
+        fname = "test"
+
+        for abspath in [True, False]:
+            subdir = tempfile.mkdtemp(dir=self.tempdir)
+            outdir = subdir if abspath else os.path.basename(subdir)
+
+            x = XDSM()
+            x.add_system("x", FUNC, "x")
+            x.write(fname, outdir=outdir)
+
+            for ext in [".tex", ".tikz", ".pdf"]:
+                self.assertTrue(os.path.isfile(os.path.join(subdir, fname + ext)))
+
+        # no files outside the subdirs
+        self.assertFalse(any(os.path.isfile(fp) for fp in os.listdir(self.tempdir)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose

It can be useful to specify an alternate working directory for writing/building the generated files, particularly in a setup where I might be running a pyxdsm script that's not in the cwd.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

Test included to exercise the option and verify files are placed correctly.

## Checklist

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation

I did run `flake8` and `black` but only took their suggestions on affected lines of code.