### PR TITLE
Make systems/inputs/outputs/connections editable 

### DIFF
--- a/pyxdsm/XDSM.py
+++ b/pyxdsm/XDSM.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import json
 import subprocess
-from collections import namedtuple
+from recordclass import recordclass
 
 from pyxdsm import __version__ as pyxdsm_version
 
@@ -110,10 +110,10 @@ def _label_to_spec(label, spec):
             spec.add(var)
 
 
-System = namedtuple("System", "node_name style label stack faded label_width spec_name")
-Input = namedtuple("Input", "node_name label label_width style stack faded")
-Output = namedtuple("Output", "node_name label label_width style stack faded side")
-Connection = namedtuple("Connection", "src target label label_width style stack faded")
+System = recordclass("System", "node_name style label stack faded label_width spec_name")
+Input = recordclass("Input", "node_name label label_width style stack faded")
+Output = recordclass("Output", "node_name label label_width style stack faded side")
+Connection = recordclass("Connection", "src target label label_width style stack faded")
 
 
 class XDSM(object):

--- a/pyxdsm/XDSM.py
+++ b/pyxdsm/XDSM.py
@@ -196,6 +196,7 @@ class XDSM(object):
 
         sys = System(node_name, style, label, stack, faded, label_width, spec_name)
         self.systems.append(sys)
+        return sys
 
     def add_input(self, name, label, label_width=None, style="DataIO", stack=False, faded=False):
         """
@@ -229,7 +230,9 @@ class XDSM(object):
         faded : bool
             If true, the component will be faded, in order to highlight some other system.
         """
-        self.ins[name] = Input("output_" + name, label, label_width, style, stack, faded)
+        inp = Input("output_" + name, label, label_width, style, stack, faded)
+        self.ins[name] = inp
+        return inp
 
     def add_output(self, name, label, label_width=None, style="DataIO", stack=False, faded=False, side="left"):
         """
@@ -268,11 +271,14 @@ class XDSM(object):
             is placed on the left-most column or the right-most column of the diagram.
         """
         if side == "left":
-            self.left_outs[name] = Output("left_output_" + name, label, label_width, style, stack, faded, side)
+            outp = Output("left_output_" + name, label, label_width, style, stack, faded, side)
+            self.left_outs[name] = outp
         elif side == "right":
-            self.right_outs[name] = Output("right_output_" + name, label, label_width, style, stack, faded, side)
+            outp = Output("right_output_" + name, label, label_width, style, stack, faded, side)
+            self.right_outs[name] = outp
         else:
             raise ValueError("The option 'side' must be given as either 'left' or 'right'!")
+        return outp
 
     def connect(
         self,
@@ -325,7 +331,9 @@ class XDSM(object):
         if (not isinstance(label_width, int)) and (label_width is not None):
             raise ValueError("label_width argument must be an integer")
 
-        self.connections.append(Connection(src, target, label, label_width, style, stack, faded))
+        connection = Connection(src, target, label, label_width, style, stack, faded)
+        self.connections.append(connection)
+        return connection
 
     def add_process(self, systems, arrow=True):
         """

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pyxdsm",
     ],
     package_data={"pyxdsm": ["*.tex"]},
-    install_requires=["numpy>=1.16"],
+    install_requires=["numpy>=1.16", "recordclass>=0.16"],
     python_requires=">=3",
     classifiers=[
         "Operating System :: OS Independent",

--- a/tests/test_xdsm.py
+++ b/tests/test_xdsm.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 import subprocess
-from pyxdsm.XDSM import XDSM, OPT, FUNC, SOLVER, LEFT, RIGHT
+from pyxdsm.XDSM import XDSM, OPT, FUNC, SOLVER, LEFT, RIGHT, IFUNC
 from numpy.distutils.exec_command import find_executable
 
 basedir = os.path.dirname(os.path.abspath(__file__))
@@ -322,6 +322,15 @@ class TestXDSM(unittest.TestCase):
 
         # no files outside the subdirs
         self.assertFalse(any(os.path.isfile(fp) for fp in os.listdir(self.tempdir)))
+
+    def test_mutability_of_systems(self):
+        x = XDSM()
+        f = x.add_system("func", FUNC, "func")
+        g = x.add_system("cons", IFUNC, "cons")
+        f.stack = True
+        g.label = "cons_new"
+        self.assertEqual(x.systems[0].stack, True)
+        self.assertEqual(x.systems[1].label, "cons_new")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
The goal of this PR is to make systems, inputs, outputs, and connections editable.
This makes it possible to generate an initial XDSM and afterwards similar XDSMs with some changes.

## Example
```
from pyxdsm.XDSM import XDSM, FUNC, LEFT

x = XDSM()

f = x.add_system("F", FUNC, "F")
g = x.add_system("G", FUNC, "G")
c = x.connect("F", "G", "x, y")
f_out = x.add_output("F", "f^*", side=LEFT)
g_out = x.add_output("G", "g^*", side=LEFT)
x.write("initial")

f.label = 'F_{new}'
f_out.label = 'f^*, z'
g.faded = True
g_out.faded = True
c.faded = True
x.write("new")
```
<table border="0">
 <tr>
<td>
Initial:
<img src="https://user-images.githubusercontent.com/28652053/204862719-a9f362f7-43f1-499d-ac37-ed5334479d9b.png"/>
</td>
<td>
New:
<img src="https://user-images.githubusercontent.com/28652053/204862811-2eb40398-b3eb-4286-b78e-855a16851670.png"/>
</td>
 </tr>
</table>



## Expected time until merged
Not urgent. Whenever you like.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
See example above.

## Checklist
- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
